### PR TITLE
Fix as emcee no longer provides an emcee.Sampler class

### DIFF
--- a/nuts/emcee_nuts.py
+++ b/nuts/emcee_nuts.py
@@ -4,13 +4,12 @@
 import numpy as np
 from .nuts import nuts6
 from .helpers import NutsSampler_fn_wrapper
-from emcee.sampler import Sampler
 
 
 __all__ = ['NUTSSampler', 'test_sampler']
 
 
-class NUTSSampler(Sampler):
+class NUTSSampler:
     """ A sampler object mirroring emcee.sampler object definition"""
 
     def __init__(self, dim, lnprobfn, gradfn=None, *args, **kwargs):


### PR DESCRIPTION
The emcee example no longer works as emcee no longer provides an emcee.Sampler class. I've therefore removed the reference to it. I don't think it's necessary for the emcee interface to work for it to be a subclass.
